### PR TITLE
fix: Greek postal code format

### DIFF
--- a/localflavor/gr/forms.py
+++ b/localflavor/gr/forms.py
@@ -8,12 +8,17 @@ class GRPostalCodeField(RegexValidator):
     """
     Greek Postal code field.
 
-    Format: XXXXX, where X is any digit, and first digit is not 0 or 9.
+    Format: XXX XX or XXXXX, where X is any digit, and first digit is not 0 or 9.
     """
 
     default_error_messages = {
-        'invalid': _('Enter a valid 5-digit postal code.'),
+        "invalid": _(
+            "Enter a valid numeric postal code in the format XXX XX or XXXXX, "
+            "where the first number cannot be 0 or 9."
+        ),
     }
 
     def __init__(self, *args, **kwargs):
-        super(GRPostalCodeField, self).__init__(r'^[12345678]\d{4}$', *args, **kwargs)
+        super(GRPostalCodeField, self).__init__(
+            r"^[1-8]\d{2} \d{2}$|^[1-8]\d{4}$", *args, **kwargs
+        )


### PR DESCRIPTION
Greek postal codes are standardly in the format `XXX XX`. They can also be written as `XXXXX`. Definition here: https://www.ecb.europa.eu/stats/money/aggregates/anacredit/shared/pdf/List_postal_code_formatting_rules_and_regular_expressions.xlsx

Currently, `localflavor` only recognises the second format, leading it to reject valid Greek postal codes.

This PR allows both formats to be validated.